### PR TITLE
Add static to cmake to build ICM libs as static libs

### DIFF
--- a/source/base/CMakeLists.txt
+++ b/source/base/CMakeLists.txt
@@ -3,7 +3,7 @@ set(GLOBALS_DIR ${PROJECT_SOURCE_DIR}/source/charging_models)
 option(ICM "compile caldera_ICM library" OFF)
 
 if(ICM)
-	add_library(Caldera_ICM_lib datatypes_module.cpp ac_to_dc_converter.cpp helper.cpp battery_calculate_limits.cpp
+	add_library(Caldera_ICM_lib STATIC datatypes_module.cpp ac_to_dc_converter.cpp helper.cpp battery_calculate_limits.cpp
 				battery_integrate_X_in_time.cpp battery.cpp vehicle_charge_model.cpp supply_equipment_load.cpp 
 				supply_equipment_control.cpp supply_equipment.cpp supply_equipment_group.cpp charge_profile_library.cpp 
 				SE_EV_factory_charge_profile.cpp charge_profile_downsample_fragments.cpp ICM_interface.cpp  
@@ -23,7 +23,7 @@ if(ICM)
 		DESTINATION ${INSTALL_DIR})
 endif()
 
-add_library(Caldera_ICM_Aux_lib datatypes_module.cpp ac_to_dc_converter.cpp helper.cpp battery_calculate_limits.cpp 
+add_library(Caldera_ICM_Aux_lib STATIC datatypes_module.cpp ac_to_dc_converter.cpp helper.cpp battery_calculate_limits.cpp 
   			battery_integrate_X_in_time.cpp battery.cpp vehicle_charge_model.cpp supply_equipment_load.cpp 
   			supply_equipment_control.cpp supply_equipment.cpp charge_profile_library.cpp SE_EV_factory_charge_profile.cpp 
   			charge_profile_downsample_fragments.cpp Aux_interface.cpp 

--- a/source/charging_models/CMakeLists.txt
+++ b/source/charging_models/CMakeLists.txt
@@ -1,5 +1,5 @@
 
-add_library(Caldera_global_lib datatypes_global.cpp ${PROJECT}/datatypes_global_SE_EV_definitions.cpp)
+add_library(Caldera_global_lib STATIC datatypes_global.cpp ${PROJECT}/datatypes_global_SE_EV_definitions.cpp)
 target_include_directories(Caldera_global_lib PUBLIC ${CMAKE_CURRENT_SOURCE_DIR})
 target_include_directories(Caldera_global_lib PUBLIC ${CMAKE_CURRENT_SOURCE_DIR}/${PROJECT})
 


### PR DESCRIPTION
In special cases libraries are built as dynamic libraries instead of static libraries. Added static in cmake to exclusively compile only static libraries.